### PR TITLE
Extend value<string> to work with other types.

### DIFF
--- a/cmake/VtgEnableWarnings.cmake
+++ b/cmake/VtgEnableWarnings.cmake
@@ -86,6 +86,7 @@ function(vtg_target_enable_warnings_for_test target)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(${target} PRIVATE -Wno-float-equal)
+    target_compile_options(${target} PRIVATE -Wno-missing-noreturn)
   endif()
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/src/argpppp/value.cppm
+++ b/src/argpppp/value.cppm
@@ -5,7 +5,6 @@ module;
 
 #include <concepts>
 #include <stdexcept>
-#include <string>
 
 export module argpppp:value;
 import :interval;
@@ -30,11 +29,12 @@ public:
     }
 };
 
-template <>
-class value<std::string> : public option_handler
+template <typename TValue>
+requires std::assignable_from<TValue&, const char*>
+class value<TValue> : public option_handler
 {
 public:
-    explicit value(std::string& target_value) : m_target_value(target_value) {}
+    explicit value(TValue& target_value) : m_target_value(target_value) {}
 
     option_handler_result handle_option(const option&, const char* arg) const override
     {
@@ -48,7 +48,7 @@ public:
     }
 
 private:
-    std::string& m_target_value;
+    TValue& m_target_value;
 };
 
 template <>

--- a/test/argpppp_unit_test/value_test.cpp
+++ b/test/argpppp_unit_test/value_test.cpp
@@ -1,10 +1,13 @@
 // SPDX-FileCopyrightText: 2025 Thomas Mathys
 // SPDX-License-Identifier: MIT
 
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_exception.hpp>
+#include <filesystem>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -14,16 +17,18 @@ import argpppp;
 namespace argpppp_unit_test
 {
 
+namespace fs = std::filesystem;
 using argpppp::error;
 using argpppp::ok;
 using argpppp::option_handler_result;
-using std::string;
 using std::make_pair;
+using std::optional;
+using std::string;
 
-TEST_CASE("value<string>")
+TEMPLATE_TEST_CASE("value<convertible from const char*>", "", fs::path, optional<fs::path>, string, optional<string>)
 {
-    string target;
-    argpppp::option opt('s', {}, {}, "STRING");
+    TestType target;
+    argpppp::option opt('o', {}, {}, "VALUE");
     argpppp::value value(target);
 
     SECTION("successful parsing")


### PR DESCRIPTION
value<string> has become value<TValue>, where TValue must be assignable from const char*. This works with the types we have primarily in mind, namely string, optional<string>, path and optional<path>

Moreover, Clang has started -Wmissing-noreturn warnings for lambda expressions. Currently it happens in the unit tests, where we certainly don't need such warnings. Fixing them would only clutter up code without benefit. Therefore we disable the warning for tests.