### PR TITLE
Add support for negative logic to value<bool>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.31.5)
-project(argpppp VERSION 0.3.0 LANGUAGES CXX)
+project(argpppp VERSION 0.4.0 LANGUAGES CXX)
 list(INSERT CMAKE_MODULE_PATH 0 "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 

--- a/src/argpppp/value.cppm
+++ b/src/argpppp/value.cppm
@@ -64,12 +64,19 @@ public:
             throw std::logic_error("arguments are not supported. value<bool> should be used for switches only");
         }
 
-        m_target_variable = true;
+        m_target_variable = m_value_when_seen;
         return ok();
+    }
+
+    value& negative()
+    {
+        m_value_when_seen = false;
+        return *this;
     }
 
 private:
     bool& m_target_variable;
+    bool m_value_when_seen = true;
 };
 
 // Note: std::unsigned_integral is currently not supported due to how strtoul and strtoull handle minus signs.

--- a/test/argpppp_unit_test/value_test.cpp
+++ b/test/argpppp_unit_test/value_test.cpp
@@ -54,8 +54,19 @@ TEST_CASE("value<bool>")
 
     SECTION("successful parsing")
     {
+        target = false;
+
         CHECK(value.handle_option(switch_opt, nullptr) == ok());
         CHECK(target == true);
+    }
+
+    SECTION("successful parsing, negative logic")
+    {
+        target = true;
+        value.negative();
+
+        CHECK(value.handle_option(switch_opt, nullptr) == ok());
+        CHECK(target == false);
     }
 
     SECTION("handling arguments is not supported")


### PR DESCRIPTION
Positive logic writes true to the target variable when the option is seen.
Negative logic writes false to the target variable when the option is seen.